### PR TITLE
fix socket_path bug

### DIFF
--- a/network/unixdomain/cli.c
+++ b/network/unixdomain/cli.c
@@ -5,7 +5,7 @@
 #include <unistd.h>
 
 //char *socket_path = "./socket";
-char *socket_path = "\0hidden";
+char socket_path[] = "\0hidden";
 
 int main(int argc, char *argv[]) {
   struct sockaddr_un addr;
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
 
   memset(&addr, 0, sizeof(addr));
   addr.sun_family = AF_UNIX;
-  strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path)-1);
+  memcpy(addr.sun_path, socket_path, sizeof(socket_path));
 
   if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
     perror("connect error");

--- a/network/unixdomain/cli.c
+++ b/network/unixdomain/cli.c
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
   char buf[100];
   int fd,rc;
 
-  if (argc > 1) socket_path=argv[1];
+  // if (argc > 1) socket_path=argv[1];
 
   if ( (fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
     perror("socket error");

--- a/network/unixdomain/srv.c
+++ b/network/unixdomain/srv.c
@@ -11,7 +11,7 @@ int main(int argc, char *argv[]) {
   char buf[100];
   int fd,cl,rc;
 
-  if (argc > 1) socket_path=argv[1];
+  // if (argc > 1) socket_path=argv[1];
 
   if ( (fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
     perror("socket error");

--- a/network/unixdomain/srv.c
+++ b/network/unixdomain/srv.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 
 //char *socket_path = "./socket";
-char *socket_path = "\0hidden";
+char socket_path[] = "\0hidden";
 
 int main(int argc, char *argv[]) {
   struct sockaddr_un addr;
@@ -20,7 +20,7 @@ int main(int argc, char *argv[]) {
 
   memset(&addr, 0, sizeof(addr));
   addr.sun_family = AF_UNIX;
-  strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path)-1);
+  memcpy(addr.sun_path, socket_path, sizeof(socket_path));
 
   unlink(socket_path);
 


### PR DESCRIPTION
hi troydhanson,
I find below line in cli.c and srv.c, you try to using name "\0hidden" as socket_path but finally '\0' is in addr.sun_path due to using strncpy, it dectect \0 so it only copy \0 to addr.sun_path.
char socket_path[] = "\0hidden";